### PR TITLE
Update to curv:0.10.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ package = "kzen-paillier"
 default-features = false
 
 [dependencies.multi-party-ecdsa]
-path = "../multi-party-ecdsa"
 #git = "https://github.com/webb-tools/multi-party-ecdsa"
+git = "https://github.com/tmpfs/multi-party-ecdsa"
+branch = "deps-update"
 default-features = false
 
 [dependencies.bitvec]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.paillier]
-version = "0.4.2"
+version = "0.4.3"
 package = "kzen-paillier"
 default-features = false
 
 [dependencies.multi-party-ecdsa]
-git = "https://github.com/webb-tools/multi-party-ecdsa"
+path = "../multi-party-ecdsa"
+#git = "https://github.com/webb-tools/multi-party-ecdsa"
 default-features = false
 
 [dependencies.bitvec]
@@ -25,8 +26,8 @@ default-features = false
 features = ["atomic", "alloc"]
 
 [dependencies]
-zk-paillier = { version = "0.4.3", default-features = false }
-curv = { package = "curv-kzen", version = "0.9", default-features = true }
+zk-paillier = { version = "0.4.4", default-features = false }
+curv = { package = "curv-kzen", version = "0.10", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 zeroize = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ features = ["atomic", "alloc"]
 
 [dependencies]
 zk-paillier = { version = "0.4.4", default-features = false }
-curv = { package = "curv-kzen", version = "0.10", default-features = true }
+curv = { package = "curv-kzen", version = "0.10", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 zeroize = "1"

--- a/src/add_party_message.rs
+++ b/src/add_party_message.rs
@@ -273,7 +273,7 @@ impl<E: Curve, H: Digest + Clone, const M: usize> JoinMessage<E, H, M> {
         }
 
         // generate the vss_scheme for the LocalKey
-        let (vss_scheme, _) = VerifiableSS::<E>::share(t, n, &new_share_fe);
+        let (vss_scheme, _) = VerifiableSS::<E, sha2::Sha256>::share(t, n, &new_share_fe);
         // TODO: secret cleanup might be needed.
 
         let local_key = LocalKey {

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -32,7 +32,7 @@ pub struct RefreshMessage<E: Curve, H: Digest + Clone, const M: usize> {
     pub(crate) party_index: u16,
     pdl_proof_vec: Vec<PDLwSlackProof<E, H>>,
     range_proofs: Vec<AliceProof<E, H>>,
-    coefficients_committed_vec: VerifiableSS<E>,
+    coefficients_committed_vec: VerifiableSS<E, sha2::Sha256>,
     pub(crate) points_committed_vec: Vec<Point<E>>,
     points_encrypted_vec: Vec<BigInt>,
     dk_correctness_proof: NiCorrectKeyProof,
@@ -58,7 +58,7 @@ impl<E: Curve, H: Digest + Clone, const M: usize> RefreshMessage<E, H, M> {
         if new_n <= local_key.t {
             return Err(FsDkrError::NewPartyUnassignedIndexError);
         }
-        let (vss_scheme, secret_shares) = VerifiableSS::<E>::share(local_key.t, new_n, &secret);
+        let (vss_scheme, secret_shares) = VerifiableSS::<E, sha2::Sha256>::share(local_key.t, new_n, &secret);
 
         local_key.vss_scheme = vss_scheme.clone();
 
@@ -209,7 +209,7 @@ impl<E: Curve, H: Digest + Clone, const M: usize> RefreshMessage<E, H, M> {
         // optimization - one decryption
         let li_vec: Vec<_> = (0..parameters.threshold as usize + 1)
             .map(|i| {
-                VerifiableSS::<E>::map_share_to_new_params(
+                VerifiableSS::<E, sha2::Sha256>::map_share_to_new_params(
                     parameters.clone().borrow(),
                     indices[i],
                     &indices,

--- a/src/test.rs
+++ b/src/test.rs
@@ -20,7 +20,11 @@ mod tests {
 
     use crate::add_party_message::JoinMessage;
     use crate::error::FsDkrResult;
-    use curv::cryptographic_primitives::hashing::Digest;
+    use curv::{
+        elliptic::curves::Scalar,
+        cryptographic_primitives::{
+            hashing::Digest, proofs::sigma_dlog::DLogProof}
+    };
     use paillier::DecryptionKey;
     use round_based::dev::Simulation;
     use std::collections::HashMap;
@@ -46,12 +50,14 @@ mod tests {
             .map(|i| keys[i].keys_linear.x_i.clone())
             .collect();
         let indices: Vec<_> = (0..(t + 1) as u16).collect();
-        let vss = VerifiableSS::<Secp256k1> {
+        let vss = VerifiableSS::<Secp256k1, sha2::Sha256> {
             parameters: ShamirSecretSharing {
                 threshold: t,
                 share_count: n,
             },
             commitments: Vec::new(),
+            proof: DLogProof::<Secp256k1, sha2::Sha256>::prove(
+                &Scalar::random()),
         };
         assert_eq!(
             vss.reconstruct(&indices[..], &old_linear_secret_key[0..(t + 1) as usize]),
@@ -85,7 +91,7 @@ mod tests {
         let offline_sign = simulate_offline_stage(keys, &[3, 4, 5]);
         simulate_signing(offline_sign, b"ZenGo");
     }
-
+    
     #[test]
     fn test_add_party_with_permute() {
         fn simulate_replace<const M: usize>(
@@ -198,12 +204,14 @@ mod tests {
             .map(|i| keys[i].keys_linear.x_i.clone())
             .collect();
         let indices: Vec<_> = (0..(t + 1) as u16).collect();
-        let vss = VerifiableSS::<Secp256k1> {
+        let vss = VerifiableSS::<Secp256k1, sha2::Sha256> {
             parameters: ShamirSecretSharing {
                 threshold: t,
                 share_count: n,
             },
             commitments: Vec::new(),
+            proof: DLogProof::<Secp256k1, sha2::Sha256>::prove(
+                &Scalar::random()),
         };
         assert_eq!(
             vss.reconstruct(&indices[..], &old_linear_secret_key[0..(t + 1) as usize]),


### PR DESCRIPTION
Also update zk-paillier and kzen-paillier.

Depends upon https://github.com/webb-tools/multi-party-ecdsa/pull/14 being merged then I can revert the `multi-party-ecdsa` dependency.

Note to self for the tests the path to the `gmp` library may need to be manually passed:

```
RUSTFLAGS="-L/opt/homebrew/Cellar/gmp/6.2.1_1/lib" cargo test
```